### PR TITLE
quick patch to fix juddering egg rendering bug

### DIFF
--- a/Items/judderingEgg.lua
+++ b/Items/judderingEgg.lua
@@ -265,8 +265,8 @@ packetSyncWurm:onReceived(function(msg)
 	end
 end)
 
--- draw wurms with this callback, so that they appear on top of foreground terrain
-Callback.add(Callback.TYPE.preHUDDraw, "SSJudderingEggDraw", function()
+-- draw wurms with a global callback, so that they appear even if their player is invisible for any reason (teleporting, dead, etc.)
+Callback.add(Callback.TYPE.onDraw, "SSJudderingEggDraw", function()
 	for id, _ in pairs(wurm_owners) do
 		if not Instance.exists(id) then
 			wurm_owners[id] = nil


### PR DESCRIPTION
i noticed that using the `preHUDDraw` callback to draw the wurms results in them rendering incorrectly at HUD scales above 1x, so i've switched it to `onDraw` which doesn't have this issue.
this does mean that the wurms now render below foreground terrain, but that's better than being effectively invisible in most cases.

the ideal solution would be to rewrite wurms as custom objects that can render at a specific depth, which i may look into in the future.